### PR TITLE
Move attribute method definition to a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ As of today, we only have `Gdocs::Models::Document#run_get` and `Gdocs::Models::
 ```rb
 require 'gdocs'
 
-d = Gdocs::Models::Document.new
+d = Gdocs::Models::Document.new(ENV['GDOCS_AUTH_TOKEN'])
 d.run_create(title: "Jimmy")
+d.document_id
 # => "1qpN_MR_i1rnu7-MD03JKUGlTvOT2GFgr5uyhhsvJ2Z8"
 
-d.run_get('1qpN_MR_i1rnu7-MD03JKUGlTvOT2GFgr5uyhhsvJ2Z8') if ENV['GDOCS_AUTH_TOKEN']
+d.run_get('1qpN_MR_i1rnu7-MD03JKUGlTvOT2GFgr5uyhhsvJ2Z8')
 d.title
 # => "Jimmy"
 ```

--- a/lib/gdocs/concerns/attributes.rb
+++ b/lib/gdocs/concerns/attributes.rb
@@ -1,0 +1,25 @@
+module Gdocs
+  module Concerns
+    module Attributes
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
+
+    private
+
+      module ClassMethods
+        def document_attributes(*attributes)
+          attributes.each do |attribute|
+            m = attribute.to_sym
+            define_method(m) do
+              # to_s.camelize(:lower) - if we have ActiveSupport as dependency
+              field = m.to_s.split('_').inject([]){ |buffer, e| buffer + [buffer.empty? ? e : e.capitalize] }.join
+              value = instance_variable_get("@#{m.to_s}") || instance_variable_set("@#{m.to_s}", @data[field])
+              value
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/test_gdocs.rb
+++ b/test/test_gdocs.rb
@@ -8,7 +8,7 @@ class TestGdocs < Minitest::Test
   end
 
   def test_document_has_a_title
-    d = Gdocs::Models::Document.new
+    d = Gdocs::Models::Document.new("ya29.abc")
     assert d.respond_to?(:run_get)
 
     d.data = {"title" => "Untitled Document"}


### PR DESCRIPTION
`Gdocs::Concerns::Attributes` module. Why? To separate concerns.

Additionally:
+ Get auth token when initialize
+ Add presence validation of auth token